### PR TITLE
Fix TypeErrors when matrix[:hash] is an Array

### DIFF
--- a/lib/travis/lint/linter.rb
+++ b/lib/travis/lint/linter.rb
@@ -124,9 +124,13 @@ module Travis
       end
 
       validator_for :all, :matrix, "Allowed matrix failures must contain a list of hashes." do |hash|
-        if hash[:matrix] and hash[:matrix][:allow_failures]
+        if hash[:matrix] && hash[:matrix].is_a?(Hash) && hash[:matrix][:allow_failures]
           !hash[:matrix][:allow_failures].any?{|failure| failure.is_a?(Hash)}
         end
+      end
+
+      validator_for :all, :matrix, "Matrix must be a hash." do |hash|
+        !(hash[:matrix].nil? || hash[:matrix].is_a?(Hash))
       end
 
       protected

--- a/spec/travis_lint_spec.rb
+++ b/spec/travis_lint_spec.rb
@@ -205,6 +205,19 @@ describe "A .travis.yml" do
   end
 
   context "with a build matrix" do
+    let(:invalid_array_matrix) {
+      {:matrix => ['foo', 'bar', 'baz']}
+    }
+
+    let(:build_matrix_is_not_hash) {
+      {:key => :matrix, :issue => "Matrix must be a hash."}
+    }
+
+    it "is invalid unless the build matrix is a hash" do
+      Travis::Lint::Linter.valid?(invalid_array_matrix).should eq(false)
+      Travis::Lint::Linter.validate(invalid_array_matrix).should include(build_matrix_is_not_hash)
+    end
+
     let(:build_matrix_is_not_list_of_hashes) {
       {:key => :matrix, :issue => "Allowed matrix failures must contain a list of hashes."}
     }


### PR DESCRIPTION
The validator which asserts that the :allow_failures key must contain a
list of hashes does not check that the matrix is a Hash. This means that
if the matrix is an Array, it fails with `TypeError: no implicit
conversion of Symbol into Integer`.

This commit adds a test demonstrating this behaviour, and fixes the
issue by adding a check in the aforementioned validator, as well as
adding another validator to check that hash[:matrix] is, in fact, a
Hash.
