### PR TITLE
perl 5.8 is actually supported on travis-ci now

### DIFF
--- a/spec/travis_lint_spec.rb
+++ b/spec/travis_lint_spec.rb
@@ -185,7 +185,7 @@ describe "A .travis.yml" do
       end
 
       let(:travis_yml) do
-        { :language => "perl", :perl => ["5.6", "5.8"] }
+        { :language => "perl", :perl => ["5.6"] }
       end
 
       it "is invalid" do


### PR DESCRIPTION
I ran travis-lint on my .travis.yml file and found it complained
about perl 5.8. Tests for 5.8 are however executing just fine:

https://travis-ci.org/mbeijen/DBD-mysql-1/builds/12478198

See also http://about.travis-ci.org/docs/user/ci-environment/#Perl-VM-images

This commit makes sure specifying 5.8 as a perl version is allowed.
